### PR TITLE
Add GET /api/version endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Add this to your project's `.cursor/mcp.json`:
 
 Then enable the server in Cursor Settings → MCP Servers → toggle **ai-todo** on.
 
+If you also expose the HTTP API, the version endpoint is available at:
+
+```bash
+curl http://127.0.0.1:8000/api/version
+```
+
 That's it! Your AI agent can now manage tasks directly. No installation required.
 
 **Try it:** Ask your agent to *"create a task for implementing user authentication"*

--- a/ai_todo/api/__init__.py
+++ b/ai_todo/api/__init__.py
@@ -1,0 +1,5 @@
+"""HTTP API helpers for ai-todo."""
+
+from ai_todo.api.server import create_http_server, run_server
+
+__all__ = ["create_http_server", "run_server"]

--- a/ai_todo/api/server.py
+++ b/ai_todo/api/server.py
@@ -40,9 +40,11 @@ class APIRequestHandler(BaseHTTPRequestHandler):
 
 
 def _handler_for_project_root(project_root: str | Path | None) -> type[APIRequestHandler]:
-    handler = type("APIRequestHandlerForProjectRoot", (APIRequestHandler,), {})
-    handler.project_root = Path(project_root) if project_root is not None else Path.cwd()
-    return handler
+    class RequestHandler(APIRequestHandler):
+        project_root = Path.cwd()
+
+    RequestHandler.project_root = Path(project_root) if project_root is not None else Path.cwd()
+    return RequestHandler
 
 
 def create_http_server(

--- a/ai_todo/api/server.py
+++ b/ai_todo/api/server.py
@@ -1,0 +1,73 @@
+"""Minimal HTTP API server for ai-todo."""
+
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import ClassVar
+from urllib.parse import urlparse
+
+from ai_todo.core.version_info import get_version_info
+
+
+class APIRequestHandler(BaseHTTPRequestHandler):
+    """HTTP request handler for ai-todo API routes."""
+
+    project_root: ClassVar[Path] = Path.cwd()
+    server_version = "ai-todo-api/1.0"
+    sys_version = ""
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib handler API
+        path = urlparse(self.path).path
+        if path == "/api/version":
+            self._send_json(HTTPStatus.OK, get_version_info(self.project_root).to_dict())
+            return
+
+        self._send_json(HTTPStatus.NOT_FOUND, {"error": "Not found"})
+
+    def _send_json(self, status: HTTPStatus, payload: dict[str, str]) -> None:
+        body = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A003 - stdlib override
+        return
+
+
+def _handler_for_project_root(project_root: str | Path | None) -> type[APIRequestHandler]:
+    handler = type("APIRequestHandlerForProjectRoot", (APIRequestHandler,), {})
+    handler.project_root = Path(project_root) if project_root is not None else Path.cwd()
+    return handler
+
+
+def create_http_server(
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    project_root: str | Path | None = None,
+) -> ThreadingHTTPServer:
+    """Create an HTTP server exposing the ai-todo API routes."""
+    return ThreadingHTTPServer((host, port), _handler_for_project_root(project_root))
+
+
+def run_server(
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    project_root: str | Path | None = None,
+) -> None:
+    """Run the ai-todo HTTP API server until interrupted."""
+    server = create_http_server(host=host, port=port, project_root=project_root)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    run_server()

--- a/ai_todo/core/version_info.py
+++ b/ai_todo/core/version_info.py
@@ -1,0 +1,71 @@
+"""Version metadata helpers for ai-todo."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from ai_todo import __version__
+
+APP_NAME = "ai-todo"
+GIT_SHA_ENV_VARS = ("GIT_COMMIT_SHA", "GITHUB_SHA", "CI_COMMIT_SHA", "COMMIT_SHA")
+
+
+@dataclass(frozen=True)
+class VersionInfo:
+    """Application version metadata."""
+
+    app_name: str
+    version: str
+    commit_sha: str | None = None
+
+    def to_dict(self) -> dict[str, str]:
+        """Serialize the version metadata for JSON responses."""
+        data: dict[str, str] = {"app_name": self.app_name, "version": self.version}
+        if self.commit_sha:
+            data["commit_sha"] = self.commit_sha
+        return data
+
+
+def _normalize_sha(value: str | None) -> str | None:
+    if value is None:
+        return None
+
+    candidate = value.strip()
+    return candidate or None
+
+
+def get_commit_sha(project_root: str | Path | None = None) -> str | None:
+    """Return the current Git commit SHA if one is available."""
+    for env_var in GIT_SHA_ENV_VARS:
+        sha = _normalize_sha(os.environ.get(env_var))
+        if sha:
+            return sha
+
+    root = Path(project_root) if project_root is not None else Path.cwd()
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(root),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    return _normalize_sha(result.stdout)
+
+
+def get_version_info(project_root: str | Path | None = None) -> VersionInfo:
+    """Return the app name, package version, and optional commit SHA."""
+    return VersionInfo(
+        app_name=APP_NAME,
+        version=__version__,
+        commit_sha=get_commit_sha(project_root),
+    )

--- a/tests/integration/test_http_api.py
+++ b/tests/integration/test_http_api.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+import threading
+from http.client import HTTPConnection
+
+import pytest
+
+from ai_todo import __version__
+from ai_todo.api.server import create_http_server
+
+
+@pytest.fixture
+def api_server(tmp_path):
+    server = create_http_server(host="127.0.0.1", port=0, project_root=tmp_path)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+def _request_json(port: int, path: str = "/api/version") -> tuple[int, dict[str, object], str]:
+    connection = HTTPConnection("127.0.0.1", port, timeout=5)
+    connection.request("GET", path)
+    response = connection.getresponse()
+    body = response.read().decode("utf-8")
+    connection.close()
+    return response.status, json.loads(body), response.getheader("Content-Type") or ""
+
+
+def test_version_endpoint_returns_app_metadata(api_server):
+    status, payload, content_type = _request_json(api_server.server_address[1])
+
+    assert status == 200
+    assert content_type == "application/json; charset=utf-8"
+    assert payload == {"app_name": "ai-todo", "version": __version__}
+
+
+def test_version_endpoint_includes_commit_sha_when_available(api_server, monkeypatch):
+    monkeypatch.setenv("GIT_COMMIT_SHA", "abc123def456")
+
+    status, payload, _ = _request_json(api_server.server_address[1])
+
+    assert status == 200
+    assert payload == {
+        "app_name": "ai-todo",
+        "version": __version__,
+        "commit_sha": "abc123def456",
+    }
+
+
+def test_unknown_route_returns_404(api_server):
+    status, payload, _ = _request_json(api_server.server_address[1], "/api/does-not-exist")
+
+    assert status == 404
+    assert payload == {"error": "Not found"}


### PR DESCRIPTION
Adds an HTTP GET /api/version endpoint that returns app name, package version, and optional git commit SHA, plus regression tests and README usage example.