### PR TITLE
ci: Dependabot auto-merge rail (PIO-1867)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,45 @@
+name: Dependabot auto-merge
+
+# Patch and minor Dependabot updates merge themselves once CI is green; major
+# updates are labelled and left for a human. Without this the PRs accumulate
+# and Dependabot's own update jobs start failing with
+# `pull_request_exists_for_latest_version` on every retry, which is what
+# produced most of this repo's red CI (PIO-1867).
+#
+# `secrets.GITHUB_TOKEN` is deliberate. A Dependabot-triggered run cannot read
+# Actions secrets, but the automatic token is still injected, and the
+# `permissions:` block below grants it what the merge needs. There is no
+# approval step because `main` here carries no required-review rule.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge patch and minor updates
+        if: >
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Label major updates for manual review
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: gh pr edit "$PR_URL" --add-label "needs-review-major"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Adds the DEC-0095 Dependabot auto-merge workflow: patch and minor updates
merge themselves once CI is green, majors get the `needs-review-major` label
and wait for a human.

## Why

Dependabot PRs were accumulating unmerged, and every later security-update job
for an already-queued dependency failed with
`pull_request_exists_for_latest_version`. Those failures were the bulk of this
repo's red CI. The red run is a symptom; the undrained queue is the defect.

Repo settings `allow_auto_merge` and `delete_branch_on_merge` were both off
and have been turned on - the same defect PIO-1457 found on hadron, and the
reason the pre-existing auto-merge workflow here could never have worked.

## Testing

Workflow linted with actionlint. Auto-merge arming is verified by the next
Dependabot PR to land on this branch, not by this PR.

## Refs

PIO-1867, DEC-0095