### PR TITLE
ci: Dependabot auto-merge rail (PIO-1867)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -44,12 +44,19 @@ jobs:
         # this label, but a workflow that depends on state it does not
         # establish turns a deleted label into a red run - the exact failure
         # mode this rail exists to remove. `--force` makes it idempotent.
+        #
+        # `--repo` is load-bearing: this job never checks the repo out, so
+        # `gh label create` has no git remote to infer a repo from and dies
+        # with "fatal: not a git repository". `gh pr edit` escapes that only
+        # because the PR URL names the repo itself.
         run: |
           gh label create "needs-review-major" \
+            --repo "$GH_REPO" \
             --color d93f0b \
             --description "Dependabot semver-major update, human review required (DEC-0095)" \
             --force
           gh pr edit "$PR_URL" --add-label "needs-review-major"
         env:
+          GH_REPO: ${{ github.repository }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Adds the DEC-0095 Dependabot auto-merge workflow: patch and minor updates
merge themselves once CI is green, majors get the `needs-review-major` label
and wait for a human.

## Why

Dependabot PRs were accumulating unmerged, and every later security-update job
for an already-queued dependency failed with
`pull_request_exists_for_latest_version`. Those failures were the bulk of this
repo's red CI. The red run is a symptom; the undrained queue is the defect.

Repo settings `allow_auto_merge` and `delete_branch_on_merge` were both off
and have been turned on - the same defect PIO-1457 found on hadron, and the
reason the pre-existing auto-merge workflow here could never have worked.

## Testing

Workflow linted with actionlint. Auto-merge arming is verified by the next
Dependabot PR to land on this branch, not by this PR.

## Refs

PIO-1867, DEC-0095